### PR TITLE
Add About page and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cosmic Footprint Society
 
-Minimal Next.js + Tailwind prototype.
+Minimal Next.js + Tailwind prototype. Includes a simple navigation bar with an About page.
 
 ## Development
 

--- a/app/src/app/about/page.tsx
+++ b/app/src/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-purple-900 via-black to-purple-900 text-white px-4 text-center">
+      <h1 className="text-3xl sm:text-4xl font-bold mb-4">About Cosmic Footprint Society</h1>
+      <p className="text-lg text-purple-300 max-w-prose">This project showcases a minimal Next.js setup with Tailwind CSS.</p>
+    </div>
+  );
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Cosmic Footprint Society",
@@ -9,7 +10,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <nav className="flex gap-4 p-4 bg-purple-900 text-purple-100">
+          <Link href="/">Home</Link>
+          <Link href="/about">About</Link>
+        </nav>
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- add an About page
- wire up basic nav links in layout
- document the About page in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f1e8bde98832aa561faa23b1d5c85